### PR TITLE
Added unittests for obstaclecontroller

### DIFF
--- a/Kartverket.Web.UnitTests/Controllers/ObstacleControllerUnitTests.cs
+++ b/Kartverket.Web.UnitTests/Controllers/ObstacleControllerUnitTests.cs
@@ -1,0 +1,85 @@
+﻿using Kartverket.Web.Controllers;
+using Kartverket.Web.Data;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.InMemory; // <-- Add this using directive
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kartverket.Web.UnitTests.Controllers
+{
+    public class ObstacleControllerUnitTests
+    {
+        private DataContext dataContext { get; set; }
+        [Fact]
+        public void DataFormReturnsCorrectView()
+        {
+            // Arrange
+            var controller = new ObstacleController(null);
+            controller.ModelState.AddModelError("ObstacleName", "Required");
+
+            // Act
+            var result = controller.DataForm() as ViewResult;
+
+            // Assert
+            Assert.Null(result.ViewName);
+        }
+
+        [Fact]
+        public void DataForm_Post_ValidModel_SavesToDatabase()
+        {
+            // Arrange
+            SetupDatabase();
+
+            var controller = new ObstacleController(dataContext);
+            var obstacleData = new Kartverket.Web.Models.ObstacleData
+            {
+                ObstacleName = "Test Obstacle",
+                ObstacleHeight = 10,
+                ObstacleDescription = "This is a test obstacle."
+            };
+
+            // Act
+            var result = controller.DataForm(obstacleData) as ViewResult;
+
+            // Assert
+            var savedObstacle = dataContext.ObstacleDatas.First();
+            Assert.Equal("This is a test obstacle.", savedObstacle.ObstacleDescription);
+        }
+
+        private  void SetupDatabase()
+        {
+            var options = new DbContextOptionsBuilder<DataContext>()
+                            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                            .Options;
+            dataContext = new DataContext(options);
+            
+        }
+
+        [Fact]
+        public void DataForm_Post_DraftModel_DoesNotSaveToDatabase()
+        {
+            // Arrange
+            var controller = CreateControllerUnderTest();
+            var obstacleData = new Kartverket.Web.Models.ObstacleData();
+          
+            // Act
+            var result = controller.DataForm(obstacleData) as ViewResult;
+
+            // Assert
+            var savedObstacle = dataContext.ObstacleDatas.FirstOrDefault();
+            Assert.Null(savedObstacle);
+        }
+
+        private ObstacleController CreateControllerUnderTest()
+        {
+            SetupDatabase();
+
+            var controller = new ObstacleController(dataContext);
+            return controller;
+        }
+    }
+}

--- a/Kartverket.Web.UnitTests/Kartverket.Web.UnitTests.csproj
+++ b/Kartverket.Web.UnitTests/Kartverket.Web.UnitTests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/Kartverket.Web/Controllers/HomeController.cs
+++ b/Kartverket.Web/Controllers/HomeController.cs
@@ -52,7 +52,7 @@ public ActionResult DataForm()
 
 // blir kalt etter at vi trykker på "Submit Data" knapp i DataForm viewet
 [HttpPost]
-public ActionResult DataForm(ObstacleData obstacledata)
+public ActionResult DataForm(Models.ObstacleData obstacledata)
 {
     return View("Overview", obstacledata);
 }


### PR DESCRIPTION
This pull request introduces unit tests for the `ObstacleController` and adds the required dependency for in-memory database testing. It also includes a minor update to the model reference in the `HomeController`. The main focus is on improving test coverage for obstacle data form handling.

### Unit testing improvements

* Added a new test class `ObstacleControllerUnitTests` in `Kartverket.Web.UnitTests/Controllers/ObstacleControllerUnitTests.cs`, including tests for view rendering, saving valid models to the database, and ensuring draft models are not saved. These tests use an in-memory database for isolation and reliability.
* Added the `Microsoft.EntityFrameworkCore.InMemory` NuGet package to `Kartverket.Web.UnitTests.csproj` to support in-memory database testing for unit tests.

### Code consistency

* Updated the `DataForm` action in `HomeController` to reference `Models.ObstacleData` for consistency with the rest of the codebase.